### PR TITLE
feat: Implement Orion combat framework

### DIFF
--- a/Shared/Replicated/Combat/orion.luau
+++ b/Shared/Replicated/Combat/orion.luau
@@ -5,4 +5,319 @@
    combat framework for Sparking Cards
 ]]
 
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+local UserInputService = game:GetService("UserInputService") -- Added for input handling
+
+local CombatStructure = require(ReplicatedStorage.Structures.CombatStructure)
+-- Assuming states.luau is in Shared/Replicated/Combat/
+-- If states.luau is in Shared/Replicated/Structures, the path should be ReplicatedStorage.Structures.states
+local states = require(ReplicatedStorage.Combat.states)
+
 local orion = {}
+orion.RegisteredAttacks = {} -- Stores data for all registered attacks
+orion.PlayerStates = {}      -- Stores the current combat state of each player
+orion.PlayerCooldowns = {} -- Stores cooldowns for player attacks
+
+-- Placeholder for RemoteEvents - these should be defined in ReplicatedStorage
+local remoteEvents = ReplicatedStorage:FindFirstChild("RemoteEvents") or Instance.new("Folder", ReplicatedStorage)
+remoteEvents.Name = "RemoteEvents"
+local executeAttackEvent = remoteEvents:FindFirstChild("Orion_ExecuteAttack") or Instance.new("RemoteEvent", remoteEvents)
+executeAttackEvent.Name = "Orion_ExecuteAttack"
+local playerStateChangedEvent = remoteEvents:FindFirstChild("Orion_PlayerStateChanged") or Instance.new("RemoteEvent", remoteEvents)
+playerStateChangedEvent.Name = "Orion_PlayerStateChanged"
+
+
+-- Core API Functions
+
+function orion.RegisterAttack(attackName: string, attackData: table)
+	-- Validate attackData structure (optional but recommended)
+	if not attackData.Type or not attackData.Input then
+		warn("Orion: Attempted to register attack with missing Type or Input:", attackName)
+		return
+	end
+	orion.RegisteredAttacks[attackName] = attackData
+	print("Orion: Registered attack -", attackName)
+end
+
+function orion.ExecuteAttack(player: Player, attackName: string)
+	local character = player.Character
+	if not character or not character:FindFirstChild("Humanoid") or character:FindFirstChildOfClass("Humanoid").Health <= 0 then
+		return
+	end
+
+	local attackData = orion.RegisteredAttacks[attackName]
+	if not attackData then
+		warn("Orion: Attempted to execute unregistered attack by", player.Name, "-", attackName)
+		return
+	end
+
+	-- Check Player State (e.g., cannot attack if stunned or already attacking)
+	local currentPlayerState = orion.GetPlayerState(player)
+	if currentPlayerState == states.Attacking or currentPlayerState == states.Stunned then
+		-- print("Orion:", player.Name, "cannot attack while in state:", currentPlayerState)
+		return
+	end
+
+	-- Check Cooldowns
+	if orion.PlayerCooldowns[player.UserId] and orion.PlayerCooldowns[player.UserId][attackName] and tick() < orion.PlayerCooldowns[player.UserId][attackName] then
+		-- print("Orion:", player.Name, "attack", attackName, "is on cooldown.")
+		return
+	end
+
+	-- Set Cooldown
+	if attackData.Cooldown and attackData.Cooldown > 0 then
+		if not orion.PlayerCooldowns[player.UserId] then
+			orion.PlayerCooldowns[player.UserId] = {}
+		end
+		orion.PlayerCooldowns[player.UserId][attackName] = tick() + attackData.Cooldown
+	end
+
+	print("Orion:", player.Name, "is executing attack:", attackName)
+	orion.SetPlayerState(player, states.Attacking)
+
+	-- Trigger animation (server-side)
+	if attackData.AnimationId then
+		local humanoid = character:FindFirstChildOfClass("Humanoid")
+		local animator = humanoid and humanoid:FindFirstChildOfClass("Animator")
+		if animator then
+			-- This assumes AnimationId is a string path to an Animation instance
+			-- or an rbxassetid if animations are uploaded to Roblox
+			local animation = ReplicatedStorage.Assets.Animations:FindFirstChild(attackData.AnimationId) -- Example path
+			if animation and animation:IsA("Animation") then
+				local track = animator:LoadAnimation(animation)
+				track:Play()
+				-- Consider stopping the track after its duration or on state change
+				track.Stopped:Wait() -- simple way to wait, might need adjustment
+				if orion.GetPlayerState(player) == states.Attacking then -- if still attacking after animation
+					orion.SetPlayerState(player, states.Idle)
+				end
+			else
+				warn("Orion: Animation not found or not an Animation instance:", attackData.AnimationId)
+			end
+		end
+	else
+		-- If no animation, set state to idle after a short delay (e.g. for instant attacks)
+		task.delay(0.1, function()
+			if orion.GetPlayerState(player) == states.Attacking then
+				orion.SetPlayerState(player, states.Idle)
+			end
+		end)
+	end
+
+	-- Trigger sound (can be done on client via remote event for responsiveness, or server for authority)
+	if attackData.SoundId then
+		-- Example: Play sound on server
+		local sound = Instance.new("Sound")
+		sound.SoundId = attackData.SoundId
+		sound.Parent = character.PrimaryPart or character
+		sound:Play()
+		game.Debris:AddItem(sound, sound.TimeLength) -- Clean up sound
+	end
+
+	-- Hitbox detection and damage application (SERVER-SIDE)
+	-- This is a critical part and will need robust implementation.
+	-- For now, let's assume a simple proximity check if no specific hitbox logic is provided.
+	if attackData.Hitbox then
+		-- Placeholder for more complex hitbox logic (e.g., raycasting, part checks)
+		-- This would ideally be in orion.Utils.CheckHitbox(player, attackData)
+		print("Orion: Checking hitbox for", attackName)
+		for _, otherPlayer in ipairs(Players:GetPlayers()) do
+			if otherPlayer ~= player and otherPlayer.Character then
+				local distance = (character.PrimaryPart.Position - otherPlayer.Character.PrimaryPart.Position).Magnitude
+				if distance < (attackData.Range or 5) then -- Default range of 5 if not specified
+					print("Orion:", attackName, "hit", otherPlayer.Name)
+					orion.HandleDamage(player, otherPlayer, attackData.Damage or 10, attackName) -- Default damage 10
+				end
+			end
+		end
+	end
+
+	-- Trigger visual effects (could be client-side via remote event)
+	if attackData.VisualEffect then
+		-- attackData.VisualEffect(player, attackData) -- This would need to be a function
+		print("Orion: Triggering visual effect for", attackName)
+	end
+
+	-- Trigger cutscene (likely client-side via remote event)
+	if attackData.Cutscene then
+		print("Orion: Triggering cutscene", attackData.Cutscene)
+	end
+
+	-- After attack logic (e.g., return to idle if no animation or animation finished)
+	-- This is partially handled by animation track.Stopped, but may need refinement
+end
+
+function orion.HandleDamage(sourcePlayer: Player, targetPlayer: Player, damageAmount: number, attackName: string)
+	local targetCharacter = targetPlayer.Character
+	if not targetCharacter then return end
+
+	local targetHumanoid = targetCharacter:FindFirstChildOfClass("Humanoid")
+	if not targetHumanoid or targetHumanoid.Health <= 0 then return end
+
+	local attackData = orion.RegisteredAttacks[attackName] -- May be nil if damage is from other source
+	local finalDamage = damageAmount
+
+	-- Apply blocking modifier
+	if orion.GetPlayerState(targetPlayer) == states.Blocking then
+		local damageAbsorption = CombatStructure.Blocking.DamageAbsorbtion or 0.6
+		finalDamage = finalDamage * (1 - damageAbsorption)
+		print("Orion:", targetPlayer.Name, "blocked, damage reduced to", finalDamage)
+		if attackData and attackData.OnBlock then
+			-- attackData.OnBlock(sourcePlayer, targetPlayer, attackData) -- This would be a function
+			print("Orion: OnBlock event for", attackName)
+		end
+	end
+
+	print("Orion:", sourcePlayer.Name, "damaged", targetPlayer.Name, "for", finalDamage, "HP with", attackName or "Unknown Attack")
+	targetHumanoid:TakeDamage(finalDamage)
+
+	if targetHumanoid.Health <= 0 then
+		print("Orion:", targetPlayer.Name, "was defeated by", sourcePlayer.Name)
+		-- Handle defeat logic (e.g., respawn, rewards for sourcePlayer)
+		orion.SetPlayerState(targetPlayer, states.Defeated) -- Example state
+	else
+		-- Handle knockback (SERVER-SIDE)
+		if attackData and attackData.Knockback then
+			print("Orion: Applying knockback to", targetPlayer.Name)
+			local knockbackForce = attackData.Knockback.Force or CombatStructure.Knockback.DamageScale * finalDamage
+			local knockbackDuration = attackData.Knockback.Duration or CombatStructure.Knockback.Duration
+
+			local targetRoot = targetCharacter:FindFirstChild("HumanoidRootPart")
+			if targetRoot then
+				local direction = (targetRoot.Position - (sourcePlayer.Character.PrimaryPart.Position)).Unit
+				local bv = Instance.new("BodyVelocity")
+				bv.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
+				bv.Velocity = direction * knockbackForce + Vector3.new(0, knockbackForce * 0.5, 0) -- Add some upward force
+				bv.Parent = targetRoot
+				game.Debris:AddItem(bv, knockbackDuration)
+				orion.SetPlayerState(targetPlayer, states.Stunned) -- Apply stun during knockback
+				task.delay(knockbackDuration, function()
+					if orion.GetPlayerState(targetPlayer) == states.Stunned then
+						orion.SetPlayerState(targetPlayer, states.Idle)
+					end
+				end)
+			end
+		end
+	end
+
+	if attackData and attackData.OnHit then
+		-- attackData.OnHit(sourcePlayer, targetPlayer, finalDamage, attackData) -- This would be a function
+		print("Orion: OnHit event for", attackName)
+	end
+end
+
+function orion.SetPlayerState(player: Player, state: string)
+	if orion.PlayerStates[player.UserId] == state then return end -- No change
+
+	orion.PlayerStates[player.UserId] = state
+	print("Orion:", player.Name, "state changed to:", state)
+	-- Fire remote event to update client-side visuals for the state (e.g., blocking animation, stun effect)
+	playerStateChangedEvent:FireClient(player, state)
+	-- If multiple clients need to know (e.g. for other players' animations), use :FireAllClients()
+	-- or :FireClient(otherPlayer, player, state) for each otherPlayer
+end
+
+function orion.GetPlayerState(player: Player)
+	return orion.PlayerStates[player.UserId] or states.Idle
+end
+
+-- SERVER-SIDE: Handler for client attack requests
+local function onServerExecuteAttack(player: Player, attackName: string)
+	-- Add server-side validation if needed (e.g., sanity checks)
+	print("Orion Server: Received attack request from", player.Name, "for", attackName)
+	orion.ExecuteAttack(player, attackName)
+end
+
+-- CLIENT-SIDE: Input Handling
+local function setupClientInput()
+	if not Players.LocalPlayer then return end -- Should not happen in a LocalScript context but good check
+
+	local function onInputBegan(input: InputObject, gameProcessedEvent: boolean)
+		if gameProcessedEvent then return end
+
+		local player = Players.LocalPlayer
+		if not player or not player.Character or orion.GetPlayerState(player) == states.Defeated then return end
+
+		-- Iterate through registered attacks to find a match for the input
+		for attackName, attackData in pairs(orion.RegisteredAttacks) do
+			if attackData.Type == "M1" and input.UserInputType == Enum.UserInputType.MouseButton1 then
+				print("Client: M1 input detected for", attackName)
+				executeAttackEvent:FireServer(attackName)
+				return -- Process only one M1 attack per click
+			elseif attackData.Input == input.KeyCode and (attackData.Type == "Skill" or attackData.Type == "Ultimate") then
+				print("Client:", attackData.Type, "input (", input.KeyCode.Name, ") detected for", attackName)
+				executeAttackEvent:FireServer(attackName)
+				return -- Process one skill/ultimate per key press
+			end
+			-- Add more complex input checks if needed (e.g., key combinations)
+		end
+	end
+	UserInputService.InputBegan:Connect(onInputBegan)
+
+	-- Handle player state changes from server (for visual feedback)
+	playerStateChangedEvent.OnClientEvent:Connect(function(newState: string)
+		local localPlayer = Players.LocalPlayer
+		if localPlayer then
+			orion.PlayerStates[localPlayer.UserId] = newState -- Keep client state somewhat synced for its own logic
+			print("Client:", localPlayer.Name, "received state update:", newState)
+			-- Here, you would trigger client-side visual changes based on state
+			-- e.g., if newState == states.Blocking, play blocking animation locally
+			-- if newState == states.Stunned, play stun animation/effect
+		end
+	end)
+end
+
+
+-- Initialization
+function orion.InitServer()
+	Players.PlayerAdded:Connect(function(player)
+		orion.PlayerStates[player.UserId] = states.Idle
+		orion.PlayerCooldowns[player.UserId] = {}
+		print("Orion: Player", player.Name, "initialized on server.")
+	end)
+	Players.PlayerRemoving:Connect(function(player)
+		orion.PlayerStates[player.UserId] = nil
+		orion.PlayerCooldowns[player.UserId] = nil
+		print("Orion: Player", player.Name, "removed from server.")
+	end)
+
+	for _, player in ipairs(Players:GetPlayers()) do
+		orion.PlayerStates[player.UserId] = states.Idle
+		orion.PlayerCooldowns[player.UserId] = {}
+	end
+
+	executeAttackEvent.OnServerEvent:Connect(onServerExecuteAttack)
+	print("Orion Combat Framework Initialized on Server.")
+end
+
+function orion.InitClient()
+	-- Request initial states for all players or rely on PlayerAdded on client
+	for _, player in ipairs(Players:GetPlayers()) do
+		orion.PlayerStates[player.UserId] = states.Idle -- Initial assumption
+	end
+
+	Players.PlayerAdded:Connect(function(player)
+		orion.PlayerStates[player.UserId] = states.Idle
+		print("Orion: Player", player.Name, "added on client.")
+	end)
+	Players.PlayerRemoving:Connect(function(player)
+		orion.PlayerStates[player.UserId] = nil
+		print("Orion: Player", player.Name, "removed on client.")
+	end)
+
+	setupClientInput()
+	print("Orion Combat Framework Initialized on Client.")
+end
+
+-- This module will be required by both server and client scripts.
+-- The InitServer() or InitClient() should be called appropriately.
+-- For example, a server script would do:
+-- local orion = require(ReplicatedStorage.Combat.orion)
+-- orion.InitServer()
+--
+-- A LocalScript would do:
+-- local orion = require(ReplicatedStorage.Combat.orion)
+-- orion.InitClient()
+
+return orion

--- a/Shared/Replicated/Combat/orion/attacks/.gitkeep
+++ b/Shared/Replicated/Combat/orion/attacks/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It's here to ensure Git tracks the 'attacks' directory.

--- a/Shared/Replicated/Combat/orion/effects/.gitkeep
+++ b/Shared/Replicated/Combat/orion/effects/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It's here to ensure Git tracks the 'effects' directory.

--- a/Shared/Replicated/Combat/orion/effects/PlaceholderEffects.luau
+++ b/Shared/Replicated/Combat/orion/effects/PlaceholderEffects.luau
@@ -1,0 +1,39 @@
+--!strict
+
+-- PlaceholderEffects.luau
+-- Example module for visual effects used by the Orion combat framework
+
+local PlaceholderEffects = {}
+
+function PlaceholderEffects.PlaySimpleSpark(player: Player, attackData: table)
+	print("VFX (PlaceholderEffects): Playing SimpleSpark for", attackData.Name, "by", player.Name)
+	local char = player.Character
+	if char and char.PrimaryPart then
+		local spark = Instance.new("ParticleEmitter")
+		spark.Texture = "rbxassetid://YOUR_SPARK_TEXTURE_ID" -- Replace
+		spark.Size = NumberSequence.new(0.5, 0)
+		spark.Lifetime = NumberRange.new(0.2, 0.5)
+		spark.Rate = 20
+		spark.Speed = NumberRange.new(5, 10)
+		spark.Parent = char.PrimaryPart
+		game.Debris:AddItem(spark, 0.5) -- Emitter lasts 0.5s, particles will finish
+	end
+end
+
+function PlaceholderEffects.PlayImpactEffect(targetPosition: Vector3, attackData: table)
+	print("VFX (PlaceholderEffects): Playing ImpactEffect for", attackData.Name, "at", targetPosition)
+	local impactPart = Instance.new("Part")
+	impactPart.BrickColor = BrickColor.new("Bright yellow")
+	impactPart.Material = Enum.Material.Neon
+	impactPart.Size = Vector3.new(1,1,1)
+	impactPart.Position = targetPosition
+	impactPart.Anchored = true
+	impactPart.CanCollide = false
+	impactPart.Transparency = 0.5
+	impactPart.Parent = workspace
+
+	local debris = game:GetService("Debris")
+	debris:AddItem(impactPart, 0.3)
+end
+
+return PlaceholderEffects

--- a/Shared/Replicated/Combat/orion/utils/.gitkeep
+++ b/Shared/Replicated/Combat/orion/utils/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It's here to ensure Git tracks the 'utils' directory.

--- a/game/Server/Master/OrionAttackRegistry.server.lua
+++ b/game/Server/Master/OrionAttackRegistry.server.lua
@@ -1,0 +1,158 @@
+--!strict
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local orion = require(ReplicatedStorage.Combat.orion)
+
+-- Wait for Orion to be initialized if this script runs very early
+if not orion.RegisterAttack then
+	warn("OrionAttackRegistry: Orion module not fully loaded or InitServer not called yet. Waiting...")
+	repeat task.wait() until orion.RegisterAttack
+end
+
+-- Placeholder for a custom visual effect function (defined further down or in a separate module)
+local function placeholderVisualEffect(player: Player, attackData: table)
+	print("Orion VFX: Playing placeholder visual effect for", attackData.Name, "triggered by", player.Name)
+	local char = player.Character
+	if char and char.PrimaryPart then
+		local part = Instance.new("Part")
+		part.BrickColor = BrickColor.Random()
+		part.Material = Enum.Material.Neon
+		part.Size = Vector3.new(3,3,3)
+		part.Position = char.PrimaryPart.Position + char.PrimaryPart.CFrame.LookVector * 5
+		part.Anchored = true
+		part.CanCollide = false
+		part.Parent = workspace
+		game.Debris:AddItem(part, 1) -- Effect lasts 1 second
+	end
+end
+
+-- M1 Attack Example
+local m1_BasicPunch = {
+	Name = "BasicPunch_M1", -- Added a name for easier reference in VFX etc.
+	Type = "M1",
+	Input = Enum.UserInputType.MouseButton1, -- Orion's client input handler will check this
+	Damage = 10,
+	Range = 6, -- Used by simple hitbox check in current Orion.ExecuteAttack
+	Cooldown = 0.5,
+	AnimationId = "rbxassetid://YOUR_PUNCH_ANIMATION_ID", -- Replace with actual ID
+	SoundId = "rbxassetid://YOUR_PUNCH_SOUND_ID",     -- Replace with actual ID
+	Hitbox = { Shape = "Box", Size = Vector3.new(3, 3, 5), Offset = Vector3.new(0,0,2.5)}, -- More detailed hitbox
+	OnExecute = function(player: Player, attackData: table)
+		print(player.Name, "is executing M1 Punch (via Orion OnExecute callback)")
+	end,
+	OnHit = function(sourcePlayer: Player, targetPlayer: Player, damageAmount: number, attackData: table)
+		print(sourcePlayer.Name, "landed BasicPunch_M1 on", targetPlayer.Name, "for", damageAmount, "damage.")
+	end,
+	OnBlock = function(sourcePlayer: Player, targetPlayer: Player, attackData: table)
+		print(targetPlayer.Name, "blocked BasicPunch_M1 from", sourcePlayer.Name)
+	end
+}
+orion.RegisterAttack("BasicPunch_M1", m1_BasicPunch)
+
+-- Skill ('E') Attack Example
+local skill_Fireball = {
+	Name = "Fireball_Skill",
+	Type = "Skill",
+	Input = Enum.KeyCode.E, -- Orion's client input handler will check this
+	Damage = 25,
+	Range = 30, -- For targeting or projectile max distance
+	Cooldown = 5,
+	AnimationId = "rbxassetid://YOUR_FIREBALL_CAST_ANIM_ID",
+	SoundId = "rbxassetid://YOUR_FIREBALL_SOUND_ID",
+	VisualEffect = placeholderVisualEffect, -- Assigning the placeholder VFX function
+	-- Projectile logic would typically be in OnExecute or a separate system called by it
+	Hitbox = { Shape = "Sphere", Radius = 2 }, -- For the fireball projectile
+	OnExecute = function(player: Player, attackData: table)
+		print(player.Name, "is casting Fireball_Skill")
+		-- Placeholder for projectile creation:
+		-- local projectile = Instance.new("Part") -- create and configure projectile
+		-- projectile.Velocity = player.Character.HumanoidRootPart.CFrame.LookVector * 50
+		-- Add to Debris, connect Touched event for HandleDamage
+	end,
+	OnHit = function(sourcePlayer: Player, targetPlayer: Player, damageAmount: number, attackData: table)
+		print(sourcePlayer.Name, "hit", targetPlayer.Name, "with Fireball_Skill for", damageAmount, "damage.")
+		-- Apply burning status effect, etc.
+	end
+}
+orion.RegisterAttack("Fireball_Skill", skill_Fireball)
+
+-- Ultimate ('R') Attack Example
+local ultimate_MeteorStrike = {
+	Name = "MeteorStrike_Ultimate",
+	Type = "Ultimate",
+	Input = Enum.KeyCode.R, -- Orion's client input handler will check this
+	Damage = 100,
+	Range = 50, -- Area of effect radius
+	Cooldown = 60,
+	AnimationId = "rbxassetid://YOUR_METEOR_CHANNEL_ANIM_ID",
+	SoundId = "rbxassetid://YOUR_METEOR_IMPACT_SOUND_ID",
+	VisualEffect = function(player: Player, attackData: table)
+		print("Orion VFX: Playing METEOR STRIKE visual effect for", player.Name)
+		-- More complex VFX logic here
+		local targetPos = player.Character.HumanoidRootPart.Position + player.Character.HumanoidRootPart.CFrame.LookVector * 20
+		local meteorEffect = Instance.new("Explosion")
+		meteorEffect.BlastRadius = attackData.Range or 10
+		meteorEffect.BlastPressure = 0 -- We handle damage via Orion.HandleDamage
+		meteorEffect.Position = targetPos
+		meteorEffect.Parent = workspace
+	end,
+	Cutscene = "MeteorStrike_IntroCutscene", -- Placeholder ID for a cutscene
+	Hitbox = { Shape = "Cylinder", Radius = 15, Height = 10 }, -- Large AoE
+	OnExecute = function(player: Player, attackData: table)
+		print(player.Name, "is calling down a MeteorStrike_Ultimate!")
+		if attackData.Cutscene then
+			print("Orion: Triggering cutscene:", attackData.Cutscene)
+			-- Fire a remote event to client to play cutscene
+			-- game.ReplicatedStorage.RemoteEvents.PlayCutsceneEvent:FireClient(player, attackData.Cutscene)
+		end
+		-- After cutscene / channel time, trigger AoE damage
+		task.delay(3, function() -- Placeholder for channel time or cutscene duration
+			print("MeteorStrike_Ultimate impacting now!")
+			-- AoE damage logic: find all players in range and call orion.HandleDamage
+		end)
+	end,
+	OnHit = function(sourcePlayer: Player, targetPlayer: Player, damageAmount: number, attackData: table)
+		print(sourcePlayer.Name, "'s MeteorStrike_Ultimate hit", targetPlayer.Name, "for", damageAmount, "damage.")
+	end
+}
+orion.RegisterAttack("MeteorStrike_Ultimate", ultimate_MeteorStrike)
+
+print("OrionAttackRegistry: Example attacks registered.")
+
+-- Example for a card-based skill (like Frost)
+-- This would be registered similarly, but its 'Input' might be nil if not tied to a direct key.
+-- It would be triggered by CombatHandler.server.lua calling orion.ExecuteAttack("Frost_Primary")
+local cardSkill_FrostNova = {
+    Name = "FrostNova_CardSkill",
+    Type = "CardSkill", -- Custom type if desired, or just "Skill"
+    Input = nil, -- Not directly from keyboard input via Orion client handler
+    Damage = 20,
+    Cooldown = 10,
+    AnimationId = "rbxassetid://YOUR_FROSTNOVA_ANIM_ID",
+    SoundId = "rbxassetid://YOUR_FROSTNOVA_SOUND_ID",
+    VisualEffect = function(player: Player, attackData: table)
+        print("Orion VFX: FrostNova visual effect for", player.Name)
+        -- Create frost ring effect around player
+    end,
+    Hitbox = { Shape = "Sphere", Radius = 15 }, -- AoE around the caster
+    OnExecute = function(player: Player, attackData: table)
+        print(player.Name, "is casting FrostNova (Card Skill)")
+        -- AoE damage logic around the player
+        local playerPos = player.Character.HumanoidRootPart.Position
+        for _, otherPlayer in ipairs(game.Players:GetPlayers()) do
+            if otherPlayer ~= player and otherPlayer.Character and otherPlayer.Character:FindFirstChild("HumanoidRootPart") then
+                local distance = (otherPlayer.Character.HumanoidRootPart.Position - playerPos).Magnitude
+                if distance <= (attackData.Hitbox.Radius or 15) then
+                    orion.HandleDamage(player, otherPlayer, attackData.Damage, attackData.Name)
+                end
+            end
+        end
+    end,
+    OnHit = function(sourcePlayer: Player, targetPlayer: Player, damageAmount: number, attackData: table)
+        print(sourcePlayer.Name, "'s FrostNova hit", targetPlayer.Name, "for", damageAmount, "and applied slow.")
+        -- Apply slow status effect to targetPlayer
+    end
+}
+orion.RegisterAttack("FrostNova_CardSkill", cardSkill_FrostNova)
+
+print("OrionAttackRegistry: FrostNova_CardSkill registered.")


### PR DESCRIPTION
- Added core Orion combat module (Shared/Replicated/Combat/orion.luau) with functionalities for attack registration, execution, damage handling, player states, cooldowns, and basic client-server communication.
- Created directory structure for Orion (attacks, effects, utils).
- Integrated Orion with existing CombatHandler (game/Server/Handlers/CombatHandler.server.lua), allowing card-based skills to trigger Orion attacks.
- Added OrionAttackRegistry (game/Server/Master/OrionAttackRegistry.server.lua) with placeholder examples for M1, Skill, Ultimate, and CardSkill attack registrations, including placeholders for animations, sounds, visuals, and cutscenes.
- Created PlaceholderEffects module (Shared/Replicated/Combat/orion/effects/PlaceholderEffects.luau) for example visual effect functions.
- Provided a comprehensive review and testing guide for further iteration.