### PR TITLE
feat: Rewrite Orion combat framework

### DIFF
--- a/Shared/Replicated/Combat/OrionFramework/CombatModule.luau
+++ b/Shared/Replicated/Combat/OrionFramework/CombatModule.luau
@@ -1,0 +1,27 @@
+--!nonstrict
+local CombatModule = {}
+CombatModule.__index = CombatModule
+
+function CombatModule.new(name)
+	local self = setmetatable({}, CombatModule)
+	self.Name = name
+	return self
+end
+
+function CombatModule:M1(character, trove, ...)
+	-- Placeholder for M1 attack
+end
+
+function CombatModule:Skill(character, trove, ...)
+	-- Placeholder for Skill attack
+end
+
+function CombatModule:Ultimate(character, trove, ...)
+	-- Placeholder for Ultimate attack
+end
+
+function CombatModule:Support(character, trove, ...)
+	-- Placeholder for Support attack
+end
+
+return CombatModule

--- a/Shared/Replicated/Combat/OrionFramework/CombatModules/Earth.luau
+++ b/Shared/Replicated/Combat/OrionFramework/CombatModules/Earth.luau
@@ -1,0 +1,4 @@
+--!nonstrict
+local CombatModule = require(script.Parent.Parent.CombatModule)
+local Earth = CombatModule.new("Earth")
+return Earth

--- a/Shared/Replicated/Combat/OrionFramework/CombatModules/Fire.luau
+++ b/Shared/Replicated/Combat/OrionFramework/CombatModules/Fire.luau
@@ -1,0 +1,4 @@
+--!nonstrict
+local CombatModule = require(script.Parent.Parent.CombatModule)
+local Fire = CombatModule.new("Fire")
+return Fire

--- a/Shared/Replicated/Combat/OrionFramework/CombatModules/Frost.luau
+++ b/Shared/Replicated/Combat/OrionFramework/CombatModules/Frost.luau
@@ -1,0 +1,44 @@
+--!nonstrict
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+local Workspace = game:GetService("Workspace")
+
+local CombatModule = require(script.Parent.Parent.CombatModule)
+local Promise = require(ReplicatedStorage.Packages.promise)
+
+local Frost = CombatModule.new("Frost")
+
+function Frost:Skill(character, trove, targetPosition, range, position)
+	local rootPart = character:FindFirstChild("HumanoidRootPart")
+	if not rootPart then
+		return Promise.reject("No HumanoidRootPart found")
+	end
+
+	local startPosition = CFrame.new(rootPart.Position, position)
+	local shardsNum = 10
+	local shard = Instance.new("Part")
+	shard.Size = Vector3.new(1, 1, 3)
+	shard.Color = Color3.new(0.5, 0.8, 1)
+	shard.Material = Enum.Material.Ice
+	shard.Anchored = true
+	shard.CanCollide = false
+
+	for i = 1, shardsNum do
+		local newShard = trove:Add(shard:Clone())
+		newShard.CFrame = startPosition * CFrame.new(math.random(-5, 5), math.random(-5, 5), -i * 5)
+		newShard.Parent = Workspace
+
+		local tweenInfo = TweenInfo.new(0.5)
+		local tween = TweenService:Create(newShard, tweenInfo, { CFrame = newShard.CFrame * CFrame.new(0, 0, -20) })
+		trove:Add(tween)
+		tween:Play()
+
+		trove:Add(Promise.delay(1):andThen(function()
+			newShard:Destroy()
+		end))
+	end
+
+	return Promise.resolve()
+end
+
+return Frost

--- a/Shared/Replicated/Combat/OrionFramework/Orion.luau
+++ b/Shared/Replicated/Combat/OrionFramework/Orion.luau
@@ -1,0 +1,97 @@
+--!nonstrict
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Promise = require(ReplicatedStorage.Packages.promise)
+local Trove = require(ReplicatedStorage.Packages.trove)
+local StateMachine = require(ReplicatedStorage.Utility.statemachine)
+
+local Orion = {}
+Orion.CombatModules = {}
+
+--[[
+	Initializes the Orion framework for a given character.
+	@param character The character to initialize the framework for.
+	@returns A new Orion instance.
+]]
+function Orion.new(character)
+	local self = {}
+	setmetatable(self, { __index = Orion })
+
+	self.Character = character
+	self.Trove = Trove.new()
+	self.StateMachine = StateMachine.new({
+		Initial = "Idle",
+		States = {
+			Idle = {
+				Transitions = {
+					Attacking = "Attacking",
+				},
+			},
+			Attacking = {
+				Transitions = {
+					Idle = "Idle",
+				},
+			},
+		},
+	})
+
+	return self
+end
+
+local CombatModulesDir = script.Parent:WaitForChild("CombatModules")
+
+--[[
+	Loads a combat module by name.
+	@param moduleName The name of the module to load.
+	@returns A promise that resolves with the loaded module.
+]]
+function Orion:LoadModule(moduleName)
+	if Orion.CombatModules[moduleName] then
+		return Promise.resolve(Orion.CombatModules[moduleName])
+	end
+
+	return Promise.new(function(resolve, reject)
+		local module = CombatModulesDir:FindFirstChild(moduleName)
+		if not module or not module:IsA("ModuleScript") then
+			return reject(string.format("Combat module '%s' not found.", moduleName))
+		end
+
+		local success, result = pcall(require, module)
+		if not success then
+			return reject(string.format("Failed to load combat module '%s': %s", moduleName, tostring(result)))
+		end
+
+		Orion.CombatModules[moduleName] = result
+		resolve(result)
+	end)
+end
+
+--[[
+	Executes an attack using a loaded combat module.
+	@param moduleName The name of the combat module to use.
+	@param attackType The type of attack to execute (e.g., "M1", "Skill").
+	@param ... Additional arguments for the attack.
+]]
+function Orion:ExecuteAttack(moduleName, attackType, ...)
+	local self = self
+	return self:LoadModule(moduleName):andThen(function(module)
+		if not module[attackType] then
+			return Promise.reject(string.format("Attack type '%s' not found in module '%s'.", attackType, moduleName))
+		end
+
+		local attackTrove = Trove.new()
+		self.Trove:Add(attackTrove)
+
+		local result = module[attackType](self.Character, attackTrove, ...)
+		return Promise.resolve(result)
+	end)
+end
+
+--[[
+	Cleans up the Orion instance.
+]]
+function Orion:Destroy()
+	self.Trove:Destroy()
+end
+
+return Orion

--- a/game/Client/CombatInitializer.client.luau
+++ b/game/Client/CombatInitializer.client.luau
@@ -1,0 +1,28 @@
+--!nonstrict
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+
+local Orion = require(ReplicatedStorage.Shared.Replicated.Combat.OrionFramework.Orion)
+
+local player = Players.LocalPlayer
+local character = player.Character or player.CharacterAdded:Wait()
+
+local orionInstance = Orion.new(character)
+
+UserInputService.InputBegan:Connect(function(input, gameProcessedEvent)
+	if gameProcessedEvent then
+		return
+	end
+
+	if input.KeyCode == Enum.KeyCode.Q then
+		orionInstance:ExecuteAttack("Frost", "Skill", Vector3.new(), 50, Vector3.new())
+			:catch(function(err)
+				warn("Error executing attack:", err)
+			end)
+	end
+end)
+
+player.CharacterRemoving:Connect(function()
+	orionInstance:Destroy()
+end)


### PR DESCRIPTION
This commit rewrites the Orion combat framework to be more robust, scalable, and easier to use.

The new framework introduces several key improvements:
- A new main `Orion` module that serves as the central entry point for the framework.
- A simplified and more reliable combat module loader that correctly finds and requires modules.
- A `Trove`-based cleanup system to prevent memory leaks and ensure that all created objects are properly destroyed.
- A `CombatModule` base class to enforce a consistent structure for all combat modules.
- Proper use of `Promise` for handling asynchronous operations, making the code cleaner and more predictable.
- A new client-side entry point for initializing the framework and connecting it to user input.

The old framework had several issues, including a broken module loader, no cleanup system, and convoluted code. This rewrite addresses these issues and provides a solid foundation for building new combat features.

by Jules