### PR TITLE
Fix cyclic dependency in Orion combat system

### DIFF
--- a/Shared/Replicated/Combat/framework/attacks/Frost.lua
+++ b/Shared/Replicated/Combat/framework/attacks/Frost.lua
@@ -24,7 +24,6 @@ local debounce = require(ReplicatedStorage.Combat.framework.utils.debounce).new(
 })
 local fetchAsset = require(ReplicatedStorage.Combat.framework.utils.fetchAsset)
 local nearest = require(ReplicatedStorage.Combat.framework.utils.nearest)
-local orion = require(ReplicatedStorage.Combat.orion)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
 local promise = require(ReplicatedStorage.Packages.promise)
 local random = require(ReplicatedStorage.Utility.random)

--- a/Shared/Replicated/Combat/requirer.luau
+++ b/Shared/Replicated/Combat/requirer.luau
@@ -13,7 +13,16 @@ local requirer = {}
 
 requirer.require = function(name: string): any
 	local attack_module = nil
-	return require(ReplicatedStorage.Combat.framework.attacks["Frost"]) --placeholder
+	local success, module = pcall(function()
+		return require(ReplicatedStorage.Combat.framework.attacks[name])
+	end)
+
+	if success then
+		return module
+	else
+		warn("Could not require attack module:", name, module)
+		return nil
+	end
 end
 
 return requirer


### PR DESCRIPTION
The orion combat script was not executing combat modules due to a cyclic dependency.

- `orion.luau` required `requirer.luau`
- `requirer.luau` required `Frost.lua`
- `Frost.lua` required `orion.luau`

This commit resolves the issue by:
- Removing the unused `require` of `orion.luau` from `Frost.lua`.
- Updating `requirer.luau` to dynamically load attack modules instead of being hardcoded to `Frost.lua`.

by Jules