### PR TITLE
feat: add commands for testing combat modules

### DIFF
--- a/Shared/Replicated/Commands/Beam.luau
+++ b/Shared/Replicated/Commands/Beam.luau
@@ -1,0 +1,66 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local beam = require(ReplicatedStorage.Combat.framework.gameplay.beam)
+local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+
+-- Cmdr Command
+-- Beam.luau
+
+-- for creating beams
+
+return {
+	Name = "Beam",
+	Aliases = {},
+	Description = "Fires a beam",
+	Group = "Utility",
+	Args = {
+		{
+			Type = "player",
+			Name = "source",
+			Description = "The player to fire the beam from",
+			Default = Players.LocalPlayer,
+		},
+		{
+			Type = "number",
+			Name = "damage",
+			Description = "The amount of damage the beam deals",
+			Default = 10,
+		},
+		{
+			Type = "number",
+			Name = "width",
+			Description = "The width of the beam",
+			Default = 0.25,
+		},
+		{
+			Type = "string",
+			Name = "color",
+			Description = "RGB values for the beam color (e.g., '255,200,100')",
+			Default = "255,200,100",
+		},
+	},
+	Run = function(_, source: Player, damage: number, width: number, colorStr: string)
+		local character = source.Character
+		if not character or not character.PrimaryPart then
+			return "Source character not found"
+		end
+
+		local colorValues = colorStr:split(",")
+		local r = tonumber(colorValues[1])
+		local g = tonumber(colorValues[2])
+		local b = tonumber(colorValues[3])
+		local color = (r and g and b) and Color3.fromRGB(r, g, b) or Color3.new(1, 1, 1)
+
+		beam.Fire({
+			origin = character.PrimaryPart.Position,
+			direction = character.PrimaryPart.CFrame.LookVector,
+			damage = damage,
+			width = width,
+			color = color,
+			source = character,
+		})
+
+		return "Beam fired!"
+	end,
+}

--- a/Shared/Replicated/Commands/Explosion.luau
+++ b/Shared/Replicated/Commands/Explosion.luau
@@ -1,0 +1,62 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local explosion = require(ReplicatedStorage.Combat.framework.effects.explosion)
+local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+
+-- Cmdr Command
+-- Explosion.luau
+
+-- for creating explosions
+
+return {
+	Name = "Explosion",
+	Aliases = { "Explode", "Kaboom" },
+	Description = "Creates an explosion effect",
+	Group = "Utility",
+	Args = {
+		{
+			Type = "player",
+			Name = "target",
+			Description = "The player to center the explosion on",
+			Default = Players.LocalPlayer,
+		},
+		{
+			Type = "number",
+			Name = "duration",
+			Description = "The duration of the explosion",
+			Default = 1.5,
+		},
+		{
+			Type = "string",
+			Name = "colors",
+			Description = "Comma-separated RGB values for the explosion colors (e.g., '255,89,0,255,0,0')",
+			Default = "255,89,0,255,0,0,255,255,0",
+		},
+	},
+	Run = function(_, target: Player, duration: number, colorsStr: string)
+		local character = target.Character
+		if not character or not character.PrimaryPart then
+			return "Target character not found"
+		end
+
+		local colors = {}
+		local colorValues = colorsStr:split(",")
+		for i = 1, #colorValues, 3 do
+			local r = tonumber(colorValues[i])
+			local g = tonumber(colorValues[i + 1])
+			local b = tonumber(colorValues[i + 2])
+			if r and g and b then
+				table.insert(colors, Color3.fromRGB(r, g, b))
+			end
+		end
+
+		explosion.kaboom({
+			position = character.PrimaryPart.Position,
+			duration = duration,
+			colors = colors,
+		})
+
+		return "Explosion created!"
+	end,
+}

--- a/Shared/Replicated/Commands/Impact.luau
+++ b/Shared/Replicated/Commands/Impact.luau
@@ -1,0 +1,59 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local impact = require(ReplicatedStorage.Combat.framework.effects.impact)
+local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+
+-- Cmdr Command
+-- Impact.luau
+
+-- for creating impact effects
+
+return {
+	Name = "Impact",
+	Aliases = {},
+	Description = "Creates an impact effect",
+	Group = "Utility",
+	Args = {
+		{
+			Type = "player",
+			Name = "target",
+			Description = "The player to center the impact on",
+			Default = Players.LocalPlayer,
+		},
+		{
+			Type = "string",
+			Name = "name",
+			Description = "The name of the impact effect (e.g., 'Impact', 'CraterDust', 'Wind')",
+			Default = "Impact",
+		},
+		{
+			Type = "number",
+			Name = "magnitude",
+			Description = "The magnitude of the impact",
+			Default = 1,
+		},
+		{
+			Type = "number",
+			Name = "duration",
+			Description = "The duration of the impact",
+			Default = 1,
+		},
+	},
+	Run = function(_, target: Player, name: string, magnitude: number, duration: number)
+		local character = target.Character
+		if not character or not character.PrimaryPart then
+			return "Target character not found"
+		end
+
+		impact({
+			name = name,
+			position = character.PrimaryPart.Position,
+			direction = character.PrimaryPart.CFrame.LookVector,
+			magnitude = magnitude,
+			duration = duration,
+		})
+
+		return "Impact effect created!"
+	end,
+}


### PR DESCRIPTION
Adds three new commands to the `Shared/Replicated/Commands` directory:
- `Explosion`: Creates an explosion effect.
- `Impact`: Creates an impact effect.
- `Beam`: Fires a beam projectile.

These commands allow for easier testing of their corresponding combat modules.

by Jules