### PR TITLE
feat: Add debounce to displayorder and hud

### DIFF
--- a/game/Client/Components/hud.luau
+++ b/game/Client/Components/hud.luau
@@ -24,6 +24,7 @@ export type button = {
 	callback: () -> (),
 	icon: icon?,
 	reactor: observer.Observer<boolean>,
+	debounce: boolean,
 }
 
 export type icon = {
@@ -40,6 +41,7 @@ function hud:create(name: string, callback: () -> (), icon: icon)
 		callback = callback,
 		icon = icon,
 		reactor = observer.new(false),
+		debounce = false,
 	}
 	table.insert(hud.buttons, button)
 end
@@ -106,6 +108,16 @@ function hud:render()
 		UIAspectRatioConstraint.Parent = Icon
 
 		TextButton.MouseButton1Click:Connect(function()
+			if button.debounce then
+				return
+			end
+
+			button.debounce = true
+
+			task.delay(0.8, function()
+				button.debounce = false
+			end)
+
 			local value = getOppositeReactorValue(button.reactor)
 
 			button.reactor:Set(value)

--- a/game/Client/Interface/displayorder.luau
+++ b/game/Client/Interface/displayorder.luau
@@ -69,6 +69,16 @@ function display_order:toggle(canvas: CanvasGroup)
 		end)
 		:expect() :: interface_data
 
+	if data.debounce:Get() then
+		return
+	end
+
+	data.debounce:Set(true)
+
+	task.delay(0.5, function()
+		data.debounce:Set(false)
+	end)
+
 	local state = data.state
 
 	state:Set(not state:Get())


### PR DESCRIPTION
Adds a debounce system to `displayorder.luau` and `hud.luau` to prevent rapid toggling of UI elements.