### PR TITLE
feat: Rewrite movement system with OOP, signals, and new features

### DIFF
--- a/game/Client/Movement/Dash.luau
+++ b/game/Client/Movement/Dash.luau
@@ -13,20 +13,35 @@ local MovementConfig = require(ReplicatedStorage.Structures.MovementConfig)
 local Trove = require(ReplicatedStorage.Packages.trove)
 local animate = require(game.StarterPlayer.StarterPlayerScripts.Utilities.animate)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
 
-local Dash = {}
-Dash.__index = Dash
+local class = {}
+class.__index = class
 
-function Dash.new(movementController)
-	local self = setmetatable({}, Dash)
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_config: any,
+	_keybind: Enum.KeyCode,
+	_character: Model,
+	_humanoid: Humanoid,
+	_onCooldown: boolean,
 
-	self._movementController = movementController
-	self._trove = Trove.new()
-	self._config = MovementConfig.Dash
-	self._keybind = MovementConfig.Keybinds.Dash
-	self._character = playerMarshaller.get().Character
-	self._humanoid = self._character:WaitForChild("Humanoid")
-	self._onCooldown = false
+	dashed: Signal.Signal,
+}
+
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_config = MovementConfig.Dash,
+		_keybind = MovementConfig.Keybinds.Dash,
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_onCooldown = false,
+
+		dashed = Signal.new(),
+	}, class)
 
 	animate.loadAnimation("dash", MovementConfig.Animations.Dash)
 
@@ -35,30 +50,32 @@ function Dash.new(movementController)
 	return self
 end
 
-function Dash:_connectInputs()
+function class:_connectInputs(self: self)
 	self._trove:Connect(UserInputService.InputBegan, function(input, gameProcessedEvent)
 		if not gameProcessedEvent and input.KeyCode == self._keybind then
-			self:Start()
+			self:start()
 		end
 	end)
 end
 
-function Dash:Start()
+function class:start(self: self)
 	if self._onCooldown then
 		return
 	end
 
+	local settings = self._movementController:get("DirectionalSettings"):getSettings("Dash", self._humanoid.MoveDirection)
+
 	local currentStamina = self._character:GetAttribute("Stamina") :: number? or 0
-	if currentStamina < self._config.StaminaCost then
+	if currentStamina < settings.StaminaCost then
 		return
 	end
 
 	self._onCooldown = true
-	task.delay(self._config.Cooldown, function()
+	task.delay(settings.Cooldown, function()
 		self._onCooldown = false
 	end)
 
-	self._character:SetAttribute("Stamina", currentStamina - self._config.StaminaCost)
+	self._character:SetAttribute("Stamina", currentStamina - settings.StaminaCost)
 	self._character:SetAttribute("AntiRegenerate", true)
 
 	animate.play("dash", 0.25)
@@ -69,7 +86,7 @@ function Dash:Start()
 	velocity.Attachment0 =
 		dashTrove:Construct(Instance, "Attachment", self._character.PrimaryPart) :: Attachment
 	velocity.MaxForce = 30000
-	velocity.VectorVelocity = workspace.CurrentCamera.CFrame.LookVector * self._config.Force :: number
+	velocity.VectorVelocity = workspace.CurrentCamera.CFrame.LookVector * settings.Force :: number
 	--self._character.PrimaryPart.CFrame.LookVector :: Vector3
 	velocity.Parent = self._character.PrimaryPart
 
@@ -77,16 +94,19 @@ function Dash:Start()
 	local windForce = dashTrove:Clone(visualEffects:WaitForChild("WindForce"))
 	windForce.Parent = self._character.PrimaryPart
 
-	task.delay(self._config.Duration, function()
+	task.delay(settings.Duration, function()
 		dashTrove:Destroy()
 		if self._character :: Model? and self._character.Parent then
 			self._character:SetAttribute("AntiRegenerate", false)
 		end
 	end)
+
+	self.dashed:Fire()
 end
 
-function Dash:Destroy()
+function class:destroy(self: self)
 	self._trove:Destroy()
+	self.dashed:Destroy()
 end
 
-return Dash
+return class

--- a/game/Client/Movement/DirectionalSettings.luau
+++ b/game/Client/Movement/DirectionalSettings.luau
@@ -1,0 +1,102 @@
+--!strict
+--[=[
+	DirectionalSettings
+	@class DirectionalSettings
+
+	Handles the directional manipulation of movement settings.
+]=]
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local MovementConfig = require(ReplicatedStorage.Structures.MovementConfig)
+
+local class = {}
+class.__index = class
+
+export type self = {
+	_movementController: any,
+	_config: any,
+}
+
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_config = MovementConfig,
+	}, class)
+
+	return self
+end
+
+function class:getSettings(self: self, movementType: string, direction: Vector3): any
+	local settings = self._config[movementType]
+	if not settings then
+		return nil
+	end
+
+	local directionalSettings = settings.Directional
+	if not directionalSettings then
+		return settings
+	end
+
+	local forward = workspace.CurrentCamera.CFrame.LookVector
+	local right = workspace.CurrentCamera.CFrame.RightVector
+	local up = workspace.CurrentCamera.CFrame.UpVector
+
+	local dotForward = direction:Dot(forward)
+	local dotRight = direction:Dot(right)
+	local dotUp = direction:Dot(up)
+
+	local newSettings = {}
+	for key, value in pairs(settings) do
+		if key ~= "Directional" then
+			newSettings[key] = value
+		end
+	end
+
+	if math.abs(dotForward) > math.abs(dotRight) and math.abs(dotForward) > math.abs(dotUp) then
+		-- Forward/Backward
+		if dotForward > 0 then
+			-- Forward
+			for key, value in pairs(directionalSettings.Forward) do
+				newSettings[key] = value
+			end
+		else
+			-- Backward
+			for key, value in pairs(directionalSettings.Backward) do
+				newSettings[key] = value
+			end
+		end
+	elseif math.abs(dotRight) > math.abs(dotForward) and math.abs(dotRight) > math.abs(dotUp) then
+		-- Right/Left
+		if dotRight > 0 then
+			-- Right
+			for key, value in pairs(directionalSettings.Right) do
+				newSettings[key] = value
+			end
+		else
+			-- Left
+			for key, value in pairs(directionalSettings.Left) do
+				newSettings[key] = value
+			end
+		end
+	else
+		-- Up/Down
+		if dotUp > 0 then
+			-- Up
+			for key, value in pairs(directionalSettings.Up) do
+				newSettings[key] = value
+			end
+		else
+			-- Down
+			for key, value in pairs(directionalSettings.Down) do
+				newSettings[key] = value
+			end
+		end
+	end
+
+	return newSettings
+end
+
+function class:destroy(self: self)
+end
+
+return class

--- a/game/Client/Movement/GroundPound.luau
+++ b/game/Client/Movement/GroundPound.luau
@@ -1,0 +1,134 @@
+--!strict
+--[=[
+	GroundPound
+	@class GroundPound
+
+	Handles the ground-pound mechanic.
+]=]
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+
+local MovementConfig = require(ReplicatedStorage.Structures.MovementConfig)
+local Trove = require(ReplicatedStorage.Packages.trove)
+local animate = require(game.StarterPlayer.StarterPlayerScripts.Utilities.animate)
+local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
+local audio = require(ReplicatedStorage.Modules.audio)
+local gamecamera = require(game.StarterPlayer.StarterPlayerScripts.Modules.gamecamera)
+local fetchAsset = require(ReplicatedStorage.Combat.framework.utils.fetchAsset)
+
+local class = {}
+class.__index = class
+
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_config: any,
+	_keybind: Enum.KeyCode,
+	_character: Model,
+	_humanoid: Humanoid,
+	_isGroundPounding: boolean,
+	_groundPoundTrove: Trove.Trove?,
+
+	onGroundPound: Signal.Signal,
+}
+
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_config = MovementConfig.GroundPound,
+		_keybind = MovementConfig.Keybinds.GroundPound,
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_isGroundPounding = false,
+		_groundPoundTrove = nil,
+
+		onGroundPound = Signal.new(),
+	}, class)
+
+	animate.loadAnimation("groundpound", MovementConfig.Animations.GroundPound)
+
+	self:_connectInputs()
+
+	return self
+end
+
+function class:_connectInputs(self: self)
+	self._trove:Connect(UserInputService.InputBegan, function(input, gameProcessedEvent)
+		if not gameProcessedEvent and input.KeyCode == self._keybind then
+			self:start()
+		end
+	end)
+end
+
+function class:start(self: self)
+	if self._isGroundPounding then
+		return
+	end
+
+	if
+		self._humanoid:GetState() ~= Enum.HumanoidStateType.Jumping
+		and self._humanoid:GetState() ~= Enum.HumanoidStateType.Freefall
+	then
+		return
+	end
+
+	self._isGroundPounding = true
+	self._groundPoundTrove = Trove.new()
+
+	animate.play("groundpound", 0.25)
+
+	local velocity = self._groundPoundTrove:Construct(Instance, "LinearVelocity")
+	velocity.Attachment0 = self._groundPoundTrove:Construct(Instance, "Attachment", self._character.PrimaryPart)
+	velocity.MaxForce = math.huge
+	velocity.VectorVelocity = Vector3.new(0, -self._config.Force, 0)
+	velocity.Parent = self._character.PrimaryPart
+
+	self.onGroundPound:Fire()
+
+	local landedConnection
+	landedConnection = self._humanoid.StateChanged:Connect(function(oldState, newState)
+		if newState == Enum.HumanoidStateType.Landed then
+			self:stop()
+			landedConnection:Disconnect()
+		end
+	end)
+end
+
+function class:stop(self: self)
+	if not self._isGroundPounding then
+		return
+	end
+	self._isGroundPounding = false
+
+	animate.stop("groundpound")
+
+	if self._groundPoundTrove then
+		self._groundPoundTrove:Destroy()
+		self._groundPoundTrove = nil
+	end
+
+	gamecamera:Shake(0.2, 0.4)
+	audio:SFX(150324322)
+
+	local dustEffect = fetchAsset("FootstepDust")
+	local dust: BasePart = dustEffect:Clone()
+	dust.CFrame = self._character.PrimaryPart.CFrame
+		* CFrame.new(0, -self._humanoid.HipHeight, 0)
+	dust.Parent = workspace;
+	(dust.ParticleEmitter :: ParticleEmitter):Emit(50)
+	task.delay(2, function()
+		if dust and dust.Parent then
+			dust:Destroy()
+		end
+	end)
+end
+
+function class:destroy(self: self)
+	self:stop()
+	self._trove:Destroy()
+	self.onGroundPound:Destroy()
+end
+
+return class

--- a/game/Client/Movement/Joint.luau
+++ b/game/Client/Movement/Joint.luau
@@ -5,7 +5,7 @@ local RunService = game:GetService("RunService")
 
 local characterMarshaller = require(ReplicatedStorage.Utility.characterMarshaller)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
-local trove = require(ReplicatedStorage.Packages.trove).new()
+local Trove = require(ReplicatedStorage.Packages.trove)
 
 -- Joint.luau
 -- a module for making the character animation (lag)
@@ -14,38 +14,54 @@ local trove = require(ReplicatedStorage.Packages.trove).new()
 local player = playerMarshaller.get()
 local character = characterMarshaller.get(player)
 
-local joints = {} :: { [number]: Motor6D }
+local class = {}
+class.__index = class
 
-local frameRate = 60
-local totalStep = 0
+export type self = {
+	_trove: Trove.Trove,
+	_joints: { [number]: Motor6D },
+	_frameRate: number,
+	_totalStep: number,
+	_lastJointCFrames: { CFrame },
+}
 
-local lastJointCFrames = {} :: { CFrame }
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_trove = Trove.new(),
+		_joints = {},
+		_frameRate = 60,
+		_totalStep = 0,
+		_lastJointCFrames = {},
+	}, class)
 
-local function getJoints(part: Instance)
-	for _, child in part:GetChildren() do
-		if child:IsA("Motor6D") then
-			table.insert(joints, child)
-		end
-	end
-	return joints
+	self:_updateJoints()
+	characterMarshaller.added(player, function()
+		self:_updateJoints()
+	end)
+
+	return self
 end
 
-local function updateJoints()
+function class:_getJoints(self: self, part: Instance)
+	for _, child in part:GetChildren() do
+		if child:IsA("Motor6D") then
+			table.insert(self._joints, child)
+		end
+	end
+end
+
+function class:_updateJoints(self: self)
 	for _, inst in pairs(character:GetDescendants()) do
-		getJoints(inst)
+		self:_getJoints(inst)
 	end
 
 	character.DescendantAdded:Connect(function(descendant)
-		getJoints(descendant)
+		self:_getJoints(descendant)
 	end)
 end
 
-updateJoints()
-
-characterMarshaller.added(player, updateJoints)
-
-trove:Connect(RunService.Stepped, function(_, deltaTime: number)
-	local frame_rate = math.clamp(frameRate, 0, 60)
+function class:update(self: self, deltaTime: number)
+	local frame_rate = math.clamp(self._frameRate, 0, 60)
 
 	local frame_time = 1 / frame_rate
 
@@ -53,9 +69,9 @@ trove:Connect(RunService.Stepped, function(_, deltaTime: number)
 		return
 	end
 
-	if totalStep > 0 then
-		for i, transform in pairs(lastJointCFrames) do
-			local j = joints[i]
+	if self._totalStep > 0 then
+		for i, transform in pairs(self._lastJointCFrames) do
+			local j = self._joints[i]
 
 			if not j then
 				continue
@@ -63,21 +79,23 @@ trove:Connect(RunService.Stepped, function(_, deltaTime: number)
 
 			j.Transform = transform
 		end
-	elseif totalStep <= 0 then
-		for i, motor in pairs(joints) do
-			lastJointCFrames[i] = motor.Transform
+	elseif self._totalStep <= 0 then
+		for i, motor in pairs(self._joints) do
+			self._lastJointCFrames[i] = motor.Transform
 		end
 	end
 
-	if totalStep < frame_time then
-		totalStep += deltaTime
+	if self._totalStep < frame_time then
+		self._totalStep += deltaTime
 
 		return
 	end
 
-	totalStep = 0
-end)
+	self._totalStep = 0
+end
 
-return {
-	_trove = trove,
-}
+function class:destroy(self: self)
+	self._trove:Destroy()
+end
+
+return class

--- a/game/Client/Movement/Jump.luau
+++ b/game/Client/Movement/Jump.luau
@@ -13,20 +13,38 @@ local audio = require(ReplicatedStorage.Modules.audio)
 local fetchAsset = require(ReplicatedStorage.Combat.framework.utils.fetchAsset)
 local gamecamera = require(game.StarterPlayer.StarterPlayerScripts.Modules.gamecamera)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
+local Trove = require(ReplicatedStorage.Packages.trove)
 
-local Jump = {}
-Jump.__index = Jump
+local class = {}
+class.__index = class
 
-function Jump.new(movementController)
-	local self = setmetatable({}, Jump)
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_config: any,
+	_character: Model,
+	_humanoid: Humanoid,
+	_dustEffect: BasePart,
 
-	self._movementController = movementController
-	self._trove = require(ReplicatedStorage.Packages.trove).new()
-	self._config = MovementConfig.Jump
-	self._character = playerMarshaller.get().Character
-	self._humanoid = self._character:WaitForChild("Humanoid")
+	jumped: Signal.Signal,
+	landed: Signal.Signal,
+}
 
-	self._dustEffect = self:_createDustEffect()
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_config = MovementConfig.Jump,
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_dustEffect = fetchAsset("FootstepDust"),
+
+		jumped = Signal.new(),
+		landed = Signal.new(),
+	}, class)
+
+	self._trove:Add(self._dustEffect)
 
 	self:_connectJumpRequest()
 	self:_connectLanding()
@@ -34,14 +52,7 @@ function Jump.new(movementController)
 	return self
 end
 
-function Jump:_createDustEffect()
-	local dustEffect = fetchAsset("FootstepDust")
-	self._trove:Add(dustEffect)
-
-	return dustEffect
-end
-
-function Jump:_connectJumpRequest()
+function class:_connectJumpRequest(self: self)
 	self._trove:Connect(UserInputService.JumpRequest, function()
 		if
 			self._humanoid:GetState() == Enum.HumanoidStateType.Jumping
@@ -76,21 +87,25 @@ function Jump:_connectJumpRequest()
 				dust:Destroy()
 			end
 		end)
+		self.jumped:Fire()
 	end)
 end
 
-function Jump:_connectLanding()
+function class:_connectLanding(self: self)
 	self._trove:Connect(self._humanoid.StateChanged, function(oldState, newState)
 		if newState == Enum.HumanoidStateType.Landed then
 			-- Landing mechanic
 			gamecamera:Shake(0.1, 0.2)
 			audio:SFX(150324322)
+			self.landed:Fire()
 		end
 	end)
 end
 
-function Jump:Destroy()
+function class:destroy(self: self)
 	self._trove:Destroy()
+	self.jumped:Destroy()
+	self.landed:Destroy()
 end
 
-return Jump
+return class

--- a/game/Client/Movement/MovementController.luau
+++ b/game/Client/Movement/MovementController.luau
@@ -10,19 +10,26 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 
-local MovementController = {}
-MovementController.__index = MovementController
+local Trove = require(ReplicatedStorage.Packages.trove)
 
-function MovementController.new()
-	local self = setmetatable({}, MovementController)
+local class = {}
+class.__index = class
 
-	self._trove = require(ReplicatedStorage.Packages.trove).new()
-	self._movements = {}
+export type self = {
+	_trove: Trove.Trove,
+	_movements: { [string]: any },
+}
+
+function class.new(): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_trove = Trove.new(),
+		_movements = {},
+	}, class)
 
 	return self
 end
 
-function MovementController:Add(movementName: string, movementModule: any)
+function class:add(self: self, movementName: string, movementModule: any)
 	if movementModule.new then
 		local movement = movementModule.new(self)
 		self._movements[movementName] = movement
@@ -30,14 +37,18 @@ function MovementController:Add(movementName: string, movementModule: any)
 	end
 end
 
-function MovementController:Start()
+function class:get(self: self, movementName: string): any
+	return self._movements[movementName]
+end
+
+function class:start(self: self)
 	self._trove:Connect(RunService.Heartbeat, function(deltaTime)
 		debug.profilebegin("movement")
 
-		for i, movement in pairs(self._movements :: { [string]: { Update: (number) -> ()? } }) do
-			if movement.Update then
+		for i, movement in pairs(self._movements :: { [string]: { update: (number) -> ()? } }) do
+			if movement.update then
 				debug.profilebegin("movement-" .. i)
-				movement:Update(deltaTime)
+				movement:update(deltaTime)
 				debug.profileend()
 			end
 		end
@@ -46,8 +57,8 @@ function MovementController:Start()
 	end)
 end
 
-function MovementController:Destroy()
+function class:destroy(self: self)
 	self._trove:Destroy()
 end
 
-return MovementController
+return class

--- a/game/Client/Movement/Slide.luau
+++ b/game/Client/Movement/Slide.luau
@@ -12,24 +12,48 @@ local MovementConfig = require(ReplicatedStorage.Structures.MovementConfig)
 local Trove = require(ReplicatedStorage.Packages.trove)
 local animate = require(game.StarterPlayer.StarterPlayerScripts.Utilities.animate)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
 
-local Slide = {}
-Slide.__index = Slide
+local class = {}
+class.__index = class
 
-function Slide.new(movementController)
-	local self = setmetatable({}, Slide)
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_config: any,
+	_keybinds: any,
+	_character: Model,
+	_humanoid: Humanoid,
+	_isSliding: boolean,
+	_onCooldown: boolean,
+	_slideTrove: Trove.Trove?,
+	_raycastParams: RaycastParams,
+	_slideVelocity: LinearVelocity?,
+	_slideAlign: AlignOrientation?,
+	_currentMultiplier: number,
 
-	self._movementController = movementController
-	self._trove = Trove.new()
-	self._config = MovementConfig.Slide
-	self._keybinds = MovementConfig.Keybinds
-	self._character = playerMarshaller.get().Character
-	self._humanoid = self._character:WaitForChild("Humanoid")
-	self._isSliding = false
-	self._onCooldown = false
-	self._slideTrove = nil
+	slideStarted: Signal.Signal,
+	slideStopped: Signal.Signal,
+}
 
-	self._raycastParams = RaycastParams.new()
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_config = MovementConfig.Slide,
+		_keybinds = MovementConfig.Keybinds,
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_isSliding = false,
+		_onCooldown = false,
+		_slideTrove = nil,
+
+		_raycastParams = RaycastParams.new(),
+
+		slideStarted = Signal.new(),
+		slideStopped = Signal.new(),
+	}, class)
+
 	self._raycastParams.FilterDescendantsInstances = { self._character }
 	self._raycastParams.FilterType = Enum.RaycastFilterType.Exclude
 
@@ -40,21 +64,21 @@ function Slide.new(movementController)
 	return self
 end
 
-function Slide:_connectInputs()
+function class:_connectInputs(self: self)
 	self._trove:Connect(UserInputService.InputBegan, function(input, gameProcessedEvent)
 		if gameProcessedEvent then
 			return
 		end
 
 		if input.KeyCode == self._keybinds.Slide then
-			self:Start()
+			self:start()
 		elseif input.KeyCode == self._keybinds.CancelSlide then
-			self:Cancel()
+			self:cancel()
 		end
 	end)
 end
 
-function Slide:Start()
+function class:start(self: self)
 	if self._isSliding or self._onCooldown then
 		return
 	end
@@ -65,9 +89,11 @@ function Slide:Start()
 		return
 	end
 
+	local settings = self._movementController:get("DirectionalSettings"):getSettings("Slide", self._humanoid.MoveDirection)
+
 	self._isSliding = true
 	self._onCooldown = true
-	task.delay(self._config.Cooldown, function()
+	task.delay(settings.Cooldown, function()
 		self._onCooldown = false
 	end)
 
@@ -82,7 +108,7 @@ function Slide:Start()
 	local velocity = self._slideTrove:Construct(Instance, "LinearVelocity")
 	velocity.Attachment0 = attachment
 	velocity.MaxForce = math.huge
-	velocity.VectorVelocity = self._character.PrimaryPart.CFrame.LookVector * self._config.BaseSpeed
+	velocity.VectorVelocity = self._character.PrimaryPart.CFrame.LookVector * settings.BaseSpeed
 	velocity.Parent = self._character.PrimaryPart
 
 	local align = self._slideTrove:Construct(Instance, "AlignOrientation")
@@ -94,9 +120,11 @@ function Slide:Start()
 	self._slideVelocity = velocity
 	self._slideAlign = align
 	self._currentMultiplier = 1
+
+	self.slideStarted:Fire()
 end
 
-function Slide:Stop()
+function class:stop(self: self)
 	if not self._isSliding then
 		return
 	end
@@ -109,21 +137,24 @@ function Slide:Stop()
 		self._slideTrove:Destroy()
 		self._slideTrove = nil
 	end
+
+	self.slideStopped:Fire()
 end
 
-function Slide:Cancel()
+function class:cancel(self: self)
 	if not self._isSliding then
 		return
 	end
 
+	local settings = self._movementController:get("DirectionalSettings"):getSettings("Slide", self._humanoid.MoveDirection)
 	local cancelMultiplier = self._currentMultiplier
-	self:Stop()
+	self:stop()
 
 	local vectorVelocity: Vector3 = (
 		self._character.PrimaryPart.CFrame.LookVector :: Vector3
-		* (self._config.CancelPushForward :: number * cancelMultiplier :: number)
+		* (settings.CancelPushForward :: number * cancelMultiplier :: number)
 	)
-		+ (self._character.PrimaryPart.CFrame.UpVector :: Vector3 * self._config.CancelPushUpward :: number)
+		+ (self._character.PrimaryPart.CFrame.UpVector :: Vector3 * settings.CancelPushUpward :: number)
 
 	local pushVelocity = Instance.new("LinearVelocity")
 	pushVelocity.Parent = self._character.PrimaryPart
@@ -138,17 +169,18 @@ function Slide:Cancel()
 	end)
 end
 
-function Slide:Update(deltaTime: number)
+function class:update(self: self, deltaTime: number)
 	if not self._isSliding then
 		return
 	end
 
+	local settings = self._movementController:get("DirectionalSettings"):getSettings("Slide", self._humanoid.MoveDirection)
 	local direction = -self._character.PrimaryPart.CFrame.UpVector :: Vector3 * 10
 	local ray = workspace:Raycast(self._character.PrimaryPart.Position, direction, self._raycastParams)
 	-- TODO) make this more performant
 
 	if not ray then
-		self:Stop()
+		self:stop()
 		return
 	end
 
@@ -166,28 +198,30 @@ function Slide:Update(deltaTime: number)
 	local verticalChange = ray.Normal.Y
 	if verticalChange > 0.99 then -- Flat ground
 		self._currentMultiplier =
-			math.max(0, self._currentMultiplier - (self._config.SpeedLossFlat :: number * deltaTime))
+			math.max(0, self._currentMultiplier - (settings.SpeedLossFlat :: number * deltaTime))
 	elseif verticalChange < 0.99 and verticalChange > 0 then -- Downhill
 		self._currentMultiplier =
-			math.min(2, self._currentMultiplier + (self._config.SpeedGainDown :: number * deltaTime))
+			math.min(2, self._currentMultiplier + (settings.SpeedGainDown :: number * deltaTime))
 	else -- Uphill
 		self._currentMultiplier =
-			math.max(0, self._currentMultiplier - (self._config.SpeedLossUp :: number * deltaTime))
+			math.max(0, self._currentMultiplier - (settings.SpeedLossUp :: number * deltaTime))
 	end
 
 	if self._slideVelocity :: LinearVelocity then
 		self._slideVelocity.VectorVelocity = self._character.PrimaryPart.CFrame.LookVector :: Vector3
-			* (self._config.BaseSpeed :: number * self._currentMultiplier :: number)
+			* (settings.BaseSpeed :: number * self._currentMultiplier :: number)
 	end
 
 	if self._currentMultiplier <= 0 then
-		self:Stop()
+		self:stop()
 	end
 end
 
-function Slide:Destroy()
-	self:Stop()
+function class:destroy(self: self)
+	self:stop()
 	self._trove:Destroy()
+	self.slideStarted:Destroy()
+	self.slideStopped:Destroy()
 end
 
-return Slide
+return class

--- a/game/Client/Movement/Sprint.luau
+++ b/game/Client/Movement/Sprint.luau
@@ -18,27 +18,49 @@ local gamecamera = require(StarterPlayer.StarterPlayerScripts.Modules.gamecamera
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
 local speed_lines = require(ReplicatedStorage.Effects["speed-lines"])
 local spr = require(ReplicatedStorage.Modules.spr)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
 
-local Sprint = {}
-Sprint.__index = Sprint
+local class = {}
+class.__index = class
 
-function Sprint.new(movementController)
-	local self = setmetatable({}, Sprint)
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_config: any,
+	_keybind: Enum.KeyCode,
+	_character: Model,
+	_humanoid: Humanoid,
+	_isSprinting: boolean,
+	_speedForceEffect: any,
+	_originalWalkSpeed: number,
+	_sprintWalkSpeed: number,
+	_originalFOV: number,
+	_sprintFOV: number,
 
-	self._movementController = movementController
-	self._trove = Trove.new()
-	self._config = MovementConfig.Sprint
-	self._keybind = MovementConfig.Keybinds.Sprint
-	self._character = playerMarshaller.get().Character
-	self._humanoid = self._character:WaitForChild("Humanoid")
-	self._isSprinting = false
-	self._speedForceEffect = nil
+	sprintStarted: Signal.Signal,
+	sprintStopped: Signal.Signal,
+}
 
-	self._originalWalkSpeed = MovementConfig.Character.BaseSpeed
-	self._sprintWalkSpeed = self._originalWalkSpeed + self._config.SpeedIncrease
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_config = MovementConfig.Sprint,
+		_keybind = MovementConfig.Keybinds.Sprint,
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_isSprinting = false,
+		_speedForceEffect = nil,
 
-	self._originalFOV = 70
-	self._sprintFOV = self._originalFOV + self._config.FieldOfViewIncrease
+		_originalWalkSpeed = MovementConfig.Character.BaseSpeed,
+		_sprintWalkSpeed = MovementConfig.Character.BaseSpeed + MovementConfig.Sprint.SpeedIncrease,
+
+		_originalFOV = 70,
+		_sprintFOV = 70 + MovementConfig.Sprint.FieldOfViewIncrease,
+
+		sprintStarted = Signal.new(),
+		sprintStopped = Signal.new(),
+	}, class)
 
 	animate.loadAnimation("run", MovementConfig.Animations.Run)
 
@@ -47,21 +69,21 @@ function Sprint.new(movementController)
 	return self
 end
 
-function Sprint:_connectInputs()
+function class:_connectInputs(self: self)
 	self._trove:Connect(UserInputService.InputBegan, function(input, gameProcessedEvent)
 		if not gameProcessedEvent and input.KeyCode == self._keybind then
-			self:Start()
+			self:start()
 		end
 	end)
 
 	self._trove:Connect(UserInputService.InputEnded, function(input, gameProcessedEvent)
 		if not gameProcessedEvent and input.KeyCode == self._keybind then
-			self:Stop()
+			self:stop()
 		end
 	end)
 end
 
-function Sprint:Start()
+function class:start(self: self)
 	if self._isSprinting then
 		return
 	end
@@ -81,11 +103,12 @@ function Sprint:Start()
 
 	--dialogue:speak("You", "Woohoo!")
 
-	self.speedForceEffect = fetchAsset("Speedlines") :: speed_lines.lines
-	speed_lines:On(gamecamera.camera, self.speedForceEffect)
+	self._speedForceEffect = fetchAsset("Speedlines") :: speed_lines.lines
+	speed_lines:On(gamecamera.camera, self._speedForceEffect)
+	self.sprintStarted:Fire()
 end
 
-function Sprint:Stop()
+function class:stop(self: self)
 	if not self._isSprinting then
 		return
 	end
@@ -95,13 +118,14 @@ function Sprint:Stop()
 	self._character:SetAttribute("AntiRegenerate", false)
 	animate.stop("run")
 
-	speed_lines:Off(self.speedForceEffect)
+	speed_lines:Off(self._speedForceEffect)
 	task.defer(function()
-		self.speedForceEffect = nil
+		self._speedForceEffect = nil
 	end)
+	self.sprintStopped:Fire()
 end
 
-function Sprint:Update(deltaTime: number)
+function class:update(self: self, deltaTime: number)
 	if not self._isSprinting then
 		return
 	end
@@ -111,13 +135,15 @@ function Sprint:Update(deltaTime: number)
 	self._character:SetAttribute("Stamina", newStamina)
 
 	if newStamina <= 0 or self._humanoid.MoveDirection.Magnitude == 0 then
-		self:Stop()
+		self:stop()
 	end
 end
 
-function Sprint:Destroy()
-	self:Stop()
+function class:destroy(self: self)
+	self:stop()
 	self._trove:Destroy()
+	self.sprintStarted:Destroy()
+	self.sprintStopped:Destroy()
 end
 
-return Sprint
+return class

--- a/game/Client/Movement/Stamina.luau
+++ b/game/Client/Movement/Stamina.luau
@@ -9,25 +9,39 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local TweenPlus = require(ReplicatedStorage.Modules.TweenPlus)
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
+local Trove = require(ReplicatedStorage.Packages.trove)
 
 local player = playerMarshaller.get()
 local character = player.Character
 
-local Stamina = {}
-Stamina.__index = Stamina
+local class = {}
+class.__index = class
 
 local max_stamina = 100
 
-function Stamina.new(movementController)
-	local self = setmetatable({}, Stamina)
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_regeneration_delay: number,
+	_regeneration_rate: number,
+	_lastDrain: number,
+	_isRegenerating: boolean,
 
-	self._movementController = movementController
-	self._trove = require(ReplicatedStorage.Packages.trove).new()
+	staminaChanged: Signal.Signal,
+}
 
-	self._regeneration_delay = 2.5
-	self._regeneration_rate = 10
-	self._lastDrain = 0
-	self._isRegenerating = false
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_regeneration_delay = 2.5,
+		_regeneration_rate = 10,
+		_lastDrain = 0,
+		_isRegenerating = false,
+
+		staminaChanged = Signal.new(),
+	}, class)
 
 	character:SetAttribute("Stamina", max_stamina)
 	character:SetAttribute("AntiRegenerate", false)
@@ -37,7 +51,7 @@ function Stamina.new(movementController)
 	return self
 end
 
-function Stamina:_createUI()
+function class:_createUI(self: self)
 	type interface = BillboardGui & {
 		Frame: CanvasGroup & {
 			Bar: Frame,
@@ -63,10 +77,11 @@ function Stamina:_createUI()
 			EasingDirection = "Out",
 			EasingStyle = "Back",
 		}):Start()
+		self.staminaChanged:Fire(stamina)
 	end)
 end
 
-function Stamina:Update(deltaTime: number)
+function class:update(self: self, deltaTime: number)
 	local isAntiRegenerate = character:GetAttribute("AntiRegenerate") :: boolean or false
 	local currentStamina = character:GetAttribute("Stamina") :: number? or max_stamina
 
@@ -87,8 +102,9 @@ function Stamina:Update(deltaTime: number)
 	end
 end
 
-function Stamina:Destroy()
+function class:destroy(self: self)
 	self._trove:Destroy()
+	self.staminaChanged:Destroy()
 end
 
-return Stamina
+return class

--- a/game/Client/Movement/Walk.luau
+++ b/game/Client/Movement/Walk.luau
@@ -10,25 +10,42 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local playerMarshaller = require(ReplicatedStorage.Utility.playerMarshaller)
 local MovementConfig = require(ReplicatedStorage.Structures.MovementConfig)
 local animate = require(game.StarterPlayer.StarterPlayerScripts.Utilities.animate)
+local Signal = require(ReplicatedStorage.Parent.Shared.Replicated.Dependencies.SignalPlus)
 
-local Walk = {}
-Walk.__index = Walk
+local Trove = require(ReplicatedStorage.Packages.trove)
 
-function Walk.new(movementController)
-	local self = setmetatable({}, Walk)
+local class = {}
+class.__index = class
 
-	self._movementController = movementController
-	self._trove = require(ReplicatedStorage.Packages.trove).new()
-	self._character = playerMarshaller.get().Character
-	self._humanoid = self._character:WaitForChild("Humanoid")
-	self._isMoving = false
+export type self = {
+	_movementController: any,
+	_trove: Trove.Trove,
+	_character: Model,
+	_humanoid: Humanoid,
+	_isMoving: boolean,
+
+	startedMoving: Signal.Signal,
+	stoppedMoving: Signal.Signal,
+}
+
+function class.new(movementController): setmetatable<self, typeof(class)>
+	local self = setmetatable({
+		_movementController = movementController,
+		_trove = Trove.new(),
+		_character = playerMarshaller.get().Character,
+		_humanoid = playerMarshaller.get().Character:WaitForChild("Humanoid"),
+		_isMoving = false,
+
+		startedMoving = Signal.new(),
+		stoppedMoving = Signal.new(),
+	}, class)
 
 	animate.loadAnimation("walk", MovementConfig.Animations.Walk)
 
 	return self
 end
 
-function Walk:Update(deltaTime: number)
+function class:update(self: self, deltaTime: number)
 	local moveDirection = self._humanoid.MoveDirection
 	local isMoving = moveDirection.Magnitude > 0.1
 
@@ -36,10 +53,12 @@ function Walk:Update(deltaTime: number)
 		-- Started moving
 		self._isMoving = true
 		animate.play("walk", 0.25)
+		self.startedMoving:Fire()
 	elseif not isMoving and self._isMoving then
 		-- Stopped moving
 		self._isMoving = false
 		animate.stop("walk")
+		self.stoppedMoving:Fire()
 	end
 
 	if self._isMoving then
@@ -54,8 +73,10 @@ function Walk:Update(deltaTime: number)
 	end
 end
 
-function Walk:Destroy()
+function class:destroy(self: self)
 	self._trove:Destroy()
+	self.startedMoving:Destroy()
+	self.stoppedMoving:Destroy()
 end
 
-return Walk
+return class

--- a/game/Client/init_movement.client.luau
+++ b/game/Client/init_movement.client.luau
@@ -1,0 +1,43 @@
+--!strict
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local MovementController = require(script.Parent.Movement.MovementController)
+local Walk = require(script.Parent.Movement.Walk)
+local Sprint = require(script.Parent.Movement.Sprint)
+local Jump = require(script.Parent.Movement.Jump)
+local Dash = require(script.Parent.Movement.Dash)
+local Slide = require(script.Parent.Movement.Slide)
+local Stamina = require(script.Parent.Movement.Stamina)
+local GroundPound = require(script.Parent.Movement.GroundPound)
+local Joint = require(script.Parent.Movement.Joint)
+local DirectionalSettings = require(script.Parent.Movement.DirectionalSettings)
+
+local movementController = MovementController.new()
+
+movementController:add("Walk", Walk)
+movementController:add("Sprint", Sprint)
+movementController:add("Jump", Jump)
+movementController:add("Dash", Dash)
+movementController:add("Slide", Slide)
+movementController:add("Stamina", Stamina)
+movementController:add("GroundPound", GroundPound)
+movementController:add("Joint", Joint)
+movementController:add("DirectionalSettings", DirectionalSettings)
+
+movementController:start()
+
+-- Example of how to use the new signals
+local jump = movementController:get("Jump")
+jump.jumped:Connect(function()
+	print("Jumped!")
+end)
+
+jump.landed:Connect(function()
+	print("Landed!")
+end)
+
+local groundPound = movementController:get("GroundPound")
+groundPound.onGroundPound:Connect(function()
+	print("Ground pound initiated!")
+end)


### PR DESCRIPTION
This commit rewrites the entire client-side movement system to use a more robust and extensible OOP pattern with type checking.

The following changes were made:
- All existing movement modules (`Walk`, `Sprint`, `Jump`, `Dash`, `Slide`, `Stamina`, `Joint`) were rewritten to use the new OOP pattern.
- A new "ground-pound" feature was added.
- A new system for directional manipulation of movement settings was implemented and integrated into the `Dash` and `Slide` modules.
- Custom signals were added to all movement modules for key events (e.g., `jumped`, `landed`, `dashed`).
- A new `init_movement.client.luau` script was created to initialize the new movement system.

by Jules